### PR TITLE
feat(auth): integrate login form with backend API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://127.0.0.1:8000

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -39,7 +39,9 @@
     "password": "Password",
     "remember": "Remember me",
     "submit": "Log in",
-    "success": "Login submitted (demo).",
+    "success": "Logged in as: {{email}}",
+    "errorDefault": "Sign-in failed",
+    "errorBackendPrefix": "Details",
     "errors": {
       "required": "This field is required.",
       "email": "Enter a valid email.",

--- a/src/locales/pl/pl.json
+++ b/src/locales/pl/pl.json
@@ -38,7 +38,9 @@
     "password": "Hasło",
     "remember": "Zapamiętaj mnie",
     "submit": "Zaloguj się",
-    "success": "Logowanie wysłane (demo).",
+    "success": "Zalogowano jako: {{email}}",
+    "errorDefault": "Logowanie nieudane",
+    "errorBackendPrefix": "Szczegóły",
     "errors": {
       "required": "To pole jest wymagane.",
       "email": "Podaj poprawny adres e-mail.",

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { login } from "../services/authService";
-import { validateLogin } from "../services/loginValidationService";
+import { login } from "../services/authService"; 
+import { validateLogin } from "../services/loginValidationService"; 
 
 export default function LoginPage() {
   const { t, i18n } = useTranslation();
@@ -38,16 +38,14 @@ export default function LoginPage() {
         password: values.password,
       });
 
-      if (data?.token) {
-        (values.remember ? localStorage : sessionStorage).setItem(
-          "token",
-          data.token
-        );
-      }
+      const storage = values.remember ? localStorage : sessionStorage;
+      storage.setItem("token", data.token);
 
-      alert(`Zalogowano jako: ${values.email}`);
+      alert(t("login.success", { email: values.email }));
     } catch (err) {
-      alert(`${t("login.error") || "Błąd logowania"}: ${err.message}`);
+      const base = t("login.errorDefault");
+      const extra = err.message ? `: ${err.message}` : "";
+      alert(`${base}${extra}`);
     }
   };
 

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { login } from "../services/authService";
 import { validateLogin } from "../services/loginValidationService";
 
 export default function LoginPage() {
   const { t, i18n } = useTranslation();
+
   const [values, setValues] = useState({
     email: "",
     password: "",
@@ -26,11 +28,27 @@ export default function LoginPage() {
     setValues((v) => ({ ...v, [name]: type === "checkbox" ? checked : value }));
   };
 
-  const onSubmit = (e) => {
+  const onSubmit = async (e) => {
     e.preventDefault();
     if (!runValidate()) return;
-    console.log("LOGIN PAYLOAD:", values);
-    alert(t("login.success"));
+
+    try {
+      const data = await login({
+        email: values.email,
+        password: values.password,
+      });
+
+      if (data?.token) {
+        (values.remember ? localStorage : sessionStorage).setItem(
+          "token",
+          data.token
+        );
+      }
+
+      alert(`Zalogowano jako: ${values.email}`);
+    } catch (err) {
+      alert(`${t("login.error") || "Błąd logowania"}: ${err.message}`);
+    }
   };
 
   return (

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -1,3 +1,4 @@
+import { registerUser, login } from "../services/authService";
 import { validateRegister } from "../services/validationService";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -29,11 +30,37 @@ export default function RegisterPage() {
     setValues((v) => ({ ...v, [name]: type === "checkbox" ? checked : value }));
   };
 
-  const onSubmit = (e) => {
+  const onSubmit = async (e) => {
     e.preventDefault();
     if (!runValidate()) return;
-    console.log("REGISTER PAYLOAD:", values);
-    alert(t("register.success"));
+
+    try {
+      const payload = {
+        username: values.nickname,
+        email: values.email,
+        password: values.password,
+      };
+      const created = await registerUser(payload);
+
+      const { token } = await login({
+        email: values.email,
+        password: values.password,
+      });
+      localStorage.setItem("token", token);
+
+      alert(`Zarejestrowano: ${created.username}`);
+
+      setValues({
+        email: "",
+        nickname: "",
+        password: "",
+        confirmPassword: "",
+        agree: false,
+      });
+      setErrors({});
+    } catch (err) {
+      alert(err.message);
+    }
   };
 
   return (

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -1,4 +1,5 @@
-import { registerUser, login } from "../services/authService";
+import { registerUser } from "../services/authService";
+import { login } from "../services/authService";
 import { validateRegister } from "../services/validationService";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,44 @@
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:8000";
+
+export async function registerUser({ username, email, password }) {
+  const res = await fetch(`${API_BASE}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ username, email, password }),
+  });
+
+  if (res.status === 201) {
+    return await res.json();
+  }
+
+  let message = `Błąd rejestracji (${res.status})`;
+  try {
+    const data = await res.json();
+    if (data?.violations) {
+      message = data.violations
+        .map((v) => `${v.propertyPath}: ${v.message}`)
+        .join("\n");
+    } else if (data?.message) message = data.message;
+    else if (data?.detail) message = data.detail;
+  } catch (_) {}
+  throw new Error(message);
+}
+
+export async function login({ email, password }) {
+  const res = await fetch(`${API_BASE}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    let msg = "Logowanie nieudane";
+    try {
+      msg = (await res.json())?.message || msg;
+    } catch {}
+    throw new Error(msg);
+  }
+  return res.json();
+}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -10,7 +10,7 @@ export async function registerUser({ username, email, password }) {
     body: JSON.stringify({ username, email, password }),
   });
 
-  if (res.status === 201) {
+  if (res.status === 201 || res.ok) {
     return await res.json();
   }
 
@@ -20,7 +20,9 @@ export async function registerUser({ username, email, password }) {
     if (data?.violations) {
       message = data.violations.map((v) => v.message).join("\n");
     } else if (data?.message) {
-      message = data.message;
+      message = `Wystąpił błąd: ${data.message}`;
+    } else if (data?.detail) {
+      message = "Wystąpił błąd podczas rejestracji.";
     }
   } catch {}
   throw new Error(message);
@@ -40,10 +42,10 @@ export async function login({ email, password }) {
     let msg = "Logowanie nieudane";
     try {
       const data = await res.json();
-      msg = data.message || msg;
+      msg = data?.message || msg;
     } catch {}
     throw new Error(msg);
   }
 
-  return res.json();
+  return await res.json();
 }

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -18,27 +18,32 @@ export async function registerUser({ username, email, password }) {
   try {
     const data = await res.json();
     if (data?.violations) {
-      message = data.violations
-        .map((v) => `${v.propertyPath}: ${v.message}`)
-        .join("\n");
-    } else if (data?.message) message = data.message;
-    else if (data?.detail) message = data.detail;
-  } catch (_) {}
+      message = data.violations.map((v) => v.message).join("\n");
+    } else if (data?.message) {
+      message = data.message;
+    }
+  } catch {}
   throw new Error(message);
 }
 
 export async function login({ email, password }) {
   const res = await fetch(`${API_BASE}/api/auth/login`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
     body: JSON.stringify({ email, password }),
   });
+
   if (!res.ok) {
     let msg = "Logowanie nieudane";
     try {
-      msg = (await res.json())?.message || msg;
+      const data = await res.json();
+      msg = data.message || msg;
     } catch {}
     throw new Error(msg);
   }
+
   return res.json();
 }


### PR DESCRIPTION
Hooked LoginPage to backend: 
POST /api/auth/login.
Stores JWT in localStorage or sessionStorage depending on “remember me”.
Basic error handling with user-friendly messages.
Manually tested: successful login with a freshly registered user.

Notes:
No routes guarded yet; logout and guards will be part of a next task.

## Summary by Sourcery

Integrate frontend login and registration flows with backend authentication API, including JWT handling and basic error reporting

New Features:
- Hook up registration page to backend register endpoint with automatic login and JWT storage
- Hook up login page to backend login endpoint with JWT stored in localStorage or sessionStorage based on "remember me" setting
- Add authService module with registerUser and login functions using a configurable API base URL

Enhancements:
- Add basic error handling with user-friendly messages for authentication failures

Build:
- Introduce .env file for configuring REACT_APP_API_BASE